### PR TITLE
Add bearer token support.

### DIFF
--- a/v3/transport.go
+++ b/v3/transport.go
@@ -25,6 +25,10 @@ type Transport struct {
 	// Password is the HTTP basic auth password for API calls made by this Client.
 	Password string
 
+	// BearerToken is a bearer token to authorize the request with. If this is
+	// set, the basic auth credentials will be ignored.
+	BearerToken string
+
 	// UserAgent to be provided in API requests. Set to DefaultUserAgent if not
 	// specified.
 	UserAgent string
@@ -69,7 +73,13 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	req.Header.Set("Accept", "application/vnd.heroku+json; version=3")
 	req.Header.Set("Request-Id", uuid.New())
-	req.SetBasicAuth(t.Username, t.Password)
+
+	if t.BearerToken != "" {
+		req.Header.Add("Authorization", "Bearer "+t.BearerToken)
+	} else if t.Username != "" || t.Password != "" {
+		req.SetBasicAuth(t.Username, t.Password)
+	}
+
 	for k, v := range t.AdditionalHeaders {
 		req.Header[k] = v
 	}


### PR DESCRIPTION
Authorization tokens can be passed as bearer tokens
(https://devcenter.heroku.com/articles/platform-api-quickstart#authentication).
Add suport for this to enable usage in services that authorize users via
oauth2.