### PR TITLE
feat: Add log_drain_url option to spaces

### DIFF
--- a/script/generate
+++ b/script/generate
@@ -39,7 +39,7 @@ if [ $UPDATE_SCHEMA -eq 1 ]; then
     -H "Accept: application/vnd.heroku+json; version=$API_VERSION"
 fi
 
-go get -u github.com/interagent/schematic/cmd/schematic
+go install github.com/interagent/schematic/cmd/schematic@7f954c20daa584c8b9a5c13bce4973dbd2539482
 
 schematic "$SCHEMA_FILE" > "$GENERATED_FILE"
 

--- a/v5/heroku.go
+++ b/v5/heroku.go
@@ -15,14 +15,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/google/go-querystring/query"
 	"io"
 	"net/http"
 	"reflect"
 	"runtime"
 	"strings"
 	"time"
-
-	"github.com/google/go-querystring/query"
 )
 
 var _ = time.Second
@@ -213,12 +212,10 @@ func String(v string) *string {
 // An account represents an individual signed up to use the Heroku
 // platform.
 type Account struct {
-	AcknowledgedMsa     bool       `json:"acknowledged_msa" url:"acknowledged_msa,key"`         // deprecated. whether account has acknowledged the MSA terms of service
-	AcknowledgedMsaAt   *time.Time `json:"acknowledged_msa_at" url:"acknowledged_msa_at,key"`   // deprecated. when account has acknowledged the MSA terms of service
-	AllowTracking       bool       `json:"allow_tracking" url:"allow_tracking,key"`             // whether to allow third party web activity tracking
-	Beta                bool       `json:"beta" url:"beta,key"`                                 // whether allowed to utilize beta Heroku features
-	CountryOfResidence  *string    `json:"country_of_residence" url:"country_of_residence,key"` // country where account owner resides
-	CreatedAt           time.Time  `json:"created_at" url:"created_at,key"`                     // when account was created
+	AllowTracking       bool      `json:"allow_tracking" url:"allow_tracking,key"`             // whether to allow third party web activity tracking
+	Beta                bool      `json:"beta" url:"beta,key"`                                 // whether allowed to utilize beta Heroku features
+	CountryOfResidence  *string   `json:"country_of_residence" url:"country_of_residence,key"` // country where account owner resides
+	CreatedAt           time.Time `json:"created_at" url:"created_at,key"`                     // when account was created
 	DefaultOrganization *struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of team
 		Name string `json:"name" url:"name,key"` // unique name of team
@@ -232,7 +229,8 @@ type Account struct {
 	Federated        bool       `json:"federated" url:"federated,key"`         // whether the user is federated and belongs to an Identity Provider
 	ID               string     `json:"id" url:"id,key"`                       // unique identifier of an account
 	IdentityProvider *struct {
-		ID           string `json:"id" url:"id,key"` // unique identifier of this identity provider
+		ID           string `json:"id" url:"id,key"`     // unique identifier of this identity provider
+		Name         string `json:"name" url:"name,key"` // user-friendly unique identifier for this identity provider
 		Organization struct {
 			Name string `json:"name" url:"name,key"` // unique name of team
 		} `json:"organization" url:"organization,key"`
@@ -245,10 +243,6 @@ type Account struct {
 			Name string `json:"name" url:"name,key"` // unique name of team
 		} `json:"team" url:"team,key"`
 	} `json:"identity_provider" url:"identity_provider,key"` // Identity Provider details for federated users.
-	ItalianCustomerTerms *string `json:"italian_customer_terms" url:"italian_customer_terms,key"` // deprecated. whether account has acknowledged the Italian customer
-	// terms of service
-	ItalianPartnerTerms *string `json:"italian_partner_terms" url:"italian_partner_terms,key"` // deprecated. whether account has acknowledged the Italian provider
-	// terms of service
 	LastLogin               *time.Time `json:"last_login" url:"last_login,key"`                               // when account last authorized with Heroku
 	Name                    *string    `json:"name" url:"name,key"`                                           // full name of the account owner
 	SmsNumber               *string    `json:"sms_number" url:"sms_number,key"`                               // SMS number of account
@@ -581,7 +575,6 @@ type AddOnAttachment struct {
 	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`       // when add-on attachment was updated
 	WebURL      *string   `json:"web_url" url:"web_url,key"`             // URL for logging into web interface of add-on in attached app context
 }
-
 type AddOnAttachmentCreateOpts struct {
 	Addon     string  `json:"addon" url:"addon,key"`                             // unique identifier of add-on
 	App       string  `json:"app" url:"app,key"`                                 // unique identifier of app
@@ -795,7 +788,6 @@ type AddOnWebhook struct {
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the webhook was updated
 	URL       string    `json:"url" url:"url,key"`               // the URL where the webhook's notification requests are sent
 }
-
 type AddOnWebhookCreateOpts struct {
 	Authorization *string `json:"authorization,omitempty" url:"authorization,omitempty,key"` // a custom `Authorization` header that Heroku will include with all
 	// webhook notifications
@@ -808,7 +800,6 @@ type AddOnWebhookCreateOpts struct {
 	// `Heroku-Webhook-Hmac-SHA256` header)
 	URL string `json:"url" url:"url,key"` // the URL where the webhook's notification requests are sent
 }
-
 type AddOnWebhookCreateResult struct {
 	Addon struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
@@ -909,7 +900,6 @@ type AddOnWebhookUpdateOpts struct {
 	// `Heroku-Webhook-Hmac-SHA256` header)
 	URL *string `json:"url,omitempty" url:"url,omitempty,key"` // the URL where the webhook's notification requests are sent
 }
-
 type AddOnWebhookUpdateResult struct {
 	Addon struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
@@ -1141,7 +1131,6 @@ type App struct {
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
 	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
-
 type AppCreateOpts struct {
 	Name   *string `json:"name,omitempty" url:"name,omitempty,key"`     // unique name of app
 	Region *string `json:"region,omitempty" url:"region,omitempty,key"` // unique identifier of region
@@ -1292,7 +1281,6 @@ type AppSetup struct {
 	Status             string    `json:"status" url:"status,key"`                             // the overall status of app setup
 	UpdatedAt          time.Time `json:"updated_at" url:"updated_at,key"`                     // when app setup was updated
 }
-
 type AppSetupCreateOpts struct {
 	App *struct {
 		Locked       *bool   `json:"locked,omitempty" url:"locked,omitempty,key"`             // are other team members forbidden from joining this app.
@@ -1352,7 +1340,6 @@ type AppTransfer struct {
 	State     string    `json:"state" url:"state,key"`           // the current state of an app transfer
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app transfer was updated
 }
-
 type AppTransferCreateOpts struct {
 	App       string `json:"app" url:"app,key"`                           // unique identifier of app
 	Recipient string `json:"recipient" url:"recipient,key"`               // unique email address of account
@@ -1409,7 +1396,6 @@ type AppWebhookCreateOpts struct {
 	// `Heroku-Webhook-Hmac-SHA256` header)
 	URL string `json:"url" url:"url,key"` // the URL where the webhook's notification requests are sent
 }
-
 type AppWebhookCreateResult struct {
 	App struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of app
@@ -1506,7 +1492,6 @@ type AppWebhookUpdateOpts struct {
 	// `Heroku-Webhook-Hmac-SHA256` header)
 	URL *string `json:"url,omitempty" url:"url,omitempty,key"` // the URL where the webhook's notification requests are sent
 }
-
 type AppWebhookUpdateResult struct {
 	App struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of app
@@ -1659,12 +1644,12 @@ type AuditTrailEvent struct {
 	Type string `json:"type" url:"type,key"` // type of event
 }
 
-// List existing events. Returns all events for one date, defaulting to
-// current date. Order, actor, action, and type, and date query params
-// can be specified as query parameters. For example,
+// List existing events. Returns all events for one day, defaulting to
+// current day. Order, actor, action, and type, and day query params can
+// be specified as query parameters. For example,
 // '/enterprise-accounts/:id/events?order=desc&actor=user@example.com&act
-// ion=create&type=app&date=2020-09-30' would return events in
-// descending order and only return app created events by the user with
+// ion=create&type=app&day=2020-09-30' would return events in descending
+// order and only return app created events by the user with
 // user@example.com email address.
 func (s *Service) AuditTrailEventList(ctx context.Context, enterpriseAccountIdentity string, lr *ListRange) (*AuditTrailEvent, error) {
 	var auditTrailEvent AuditTrailEvent
@@ -1709,7 +1694,6 @@ type Build struct {
 		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
 	} `json:"user" url:"user,key"` // user that started the build
 }
-
 type BuildCreateOpts struct {
 	Buildpacks []*struct {
 		Name *string `json:"name,omitempty" url:"name,omitempty,key"` // Buildpack Registry name of the buildpack for the app
@@ -1761,7 +1745,6 @@ type BuildpackInstallation struct {
 	} `json:"buildpack" url:"buildpack,key"` // buildpack
 	Ordinal int `json:"ordinal" url:"ordinal,key"` // determines the order in which the buildpacks will execute
 }
-
 type BuildpackInstallationUpdateOpts struct {
 	Updates []struct {
 		Buildpack string `json:"buildpack" url:"buildpack,key"` // location of the buildpack for the app. Either a url (unofficial
@@ -1805,7 +1788,6 @@ type Collaborator struct {
 		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
 	} `json:"user" url:"user,key"` // identity of collaborated account
 }
-
 type CollaboratorCreateOpts struct {
 	Silent *bool  `json:"silent,omitempty" url:"silent,omitempty,key"` // whether to suppress email invitation when creating collaborator
 	User   string `json:"user" url:"user,key"`                         // unique email address of account
@@ -1839,10 +1821,8 @@ func (s *Service) CollaboratorList(ctx context.Context, appIdentity string, lr *
 
 // Config Vars allow you to manage the configuration information
 // provided to an app on Heroku.
-type (
-	ConfigVar                 map[string]string
-	ConfigVarInfoForAppResult map[string]*string
-)
+type ConfigVar map[string]string
+type ConfigVarInfoForAppResult map[string]*string
 
 // Get config-vars for app.
 func (s *Service) ConfigVarInfoForApp(ctx context.Context, appIdentity string) (ConfigVarInfoForAppResult, error) {
@@ -1878,7 +1858,6 @@ type Credit struct {
 	Title     string    `json:"title" url:"title,key"`           // a name for credit
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when credit was updated
 }
-
 type CreditCreateOpts struct {
 	Code1 *string `json:"code1,omitempty" url:"code1,omitempty,key"` // first code from a discount card
 	Code2 *string `json:"code2,omitempty" url:"code2,omitempty,key"` // second code from a discount card
@@ -1924,7 +1903,6 @@ type Domain struct {
 	Status    string    `json:"status" url:"status,key"`         // status of this record's cname
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when domain was updated
 }
-
 type DomainCreateDeprecatedOpts struct {
 	Hostname string `json:"hostname" url:"hostname,key"` // full hostname
 }
@@ -2005,7 +1983,6 @@ type Dyno struct {
 	Type      string    `json:"type" url:"type,key"`             // type of process
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when process last changed state
 }
-
 type DynoCreateOpts struct {
 	Attach     *bool             `json:"attach,omitempty" url:"attach,omitempty,key"`             // whether to stream output or not
 	Command    string            `json:"command" url:"command,key"`                               // command used to start this process
@@ -2160,16 +2137,23 @@ type EnterpriseAccountDailyUsage struct {
 		Space   float64 `json:"space" url:"space,key"`     // space credits used
 	} `json:"teams" url:"teams,key"` // usage by team
 }
+type EnterpriseAccountDailyUsageInfoOpts struct {
+	End   *string `json:"end,omitempty" url:"end,omitempty,key"` // range end date
+	Start string  `json:"start" url:"start,key"`                 // range start date
+}
 type EnterpriseAccountDailyUsageInfoResult []EnterpriseAccountDailyUsage
 
 // Retrieves usage for an enterprise account for a range of days. Start
 // and end dates can be specified as query parameters using the date
-// format, YYYY-MM-DD format. For example,
-// '/enterprise-accounts/example-account/usage/daily?start=2019-01-01&end
-// =2019-01-31' specifies all days in January for 2019.
-func (s *Service) EnterpriseAccountDailyUsageInfo(ctx context.Context, enterpriseAccountID string, lr *ListRange) (EnterpriseAccountDailyUsageInfoResult, error) {
+// format YYYY-MM-DD.
+// The enterprise account identifier can be found
+// from the [enterprise account
+// list](https://devcenter.heroku.com/articles/platform-api-reference#ent
+// erprise-account-list).
+//
+func (s *Service) EnterpriseAccountDailyUsageInfo(ctx context.Context, enterpriseAccountID string, o EnterpriseAccountDailyUsageInfoOpts, lr *ListRange) (EnterpriseAccountDailyUsageInfoResult, error) {
 	var enterpriseAccountDailyUsage EnterpriseAccountDailyUsageInfoResult
-	return enterpriseAccountDailyUsage, s.Get(ctx, &enterpriseAccountDailyUsage, fmt.Sprintf("/enterprise-accounts/%v/usage/daily", enterpriseAccountID), nil, lr)
+	return enterpriseAccountDailyUsage, s.Get(ctx, &enterpriseAccountDailyUsage, fmt.Sprintf("/enterprise-accounts/%v/usage/daily", enterpriseAccountID), o, lr)
 }
 
 // Enterprise account members are users with access to an enterprise
@@ -2266,17 +2250,24 @@ type EnterpriseAccountMonthlyUsage struct {
 		Space   float64 `json:"space" url:"space,key"`     // space credits used
 	} `json:"teams" url:"teams,key"` // usage by team
 }
+type EnterpriseAccountMonthlyUsageInfoOpts struct {
+	End   *string `json:"end,omitempty" url:"end,omitempty,key"` // range end date
+	Start string  `json:"start" url:"start,key"`                 // range start date
+}
 type EnterpriseAccountMonthlyUsageInfoResult []EnterpriseAccountMonthlyUsage
 
 // Retrieves usage for an enterprise account for a range of months.
 // Start and end dates can be specified as query parameters using the
-// date format, YYYY-MM format. For example,
-// '/enterprise-accounts/example-account/usage/monthly?start=2019-01&end=
-// 2019-02' specifies usage in January and February for 2019. If no end
-// date is specified, one month of usage is returned.
-func (s *Service) EnterpriseAccountMonthlyUsageInfo(ctx context.Context, enterpriseAccountID string, lr *ListRange) (EnterpriseAccountMonthlyUsageInfoResult, error) {
+// date format YYYY-MM. If no end date is specified, one month of usage
+// is returned.
+// The enterprise account identifier can be found from the
+// [enterprise account
+// list](https://devcenter.heroku.com/articles/platform-api-reference#ent
+// erprise-account-list).
+//
+func (s *Service) EnterpriseAccountMonthlyUsageInfo(ctx context.Context, enterpriseAccountID string, o EnterpriseAccountMonthlyUsageInfoOpts, lr *ListRange) (EnterpriseAccountMonthlyUsageInfoResult, error) {
 	var enterpriseAccountMonthlyUsage EnterpriseAccountMonthlyUsageInfoResult
-	return enterpriseAccountMonthlyUsage, s.Get(ctx, &enterpriseAccountMonthlyUsage, fmt.Sprintf("/enterprise-accounts/%v/usage/monthly", enterpriseAccountID), nil, lr)
+	return enterpriseAccountMonthlyUsage, s.Get(ctx, &enterpriseAccountMonthlyUsage, fmt.Sprintf("/enterprise-accounts/%v/usage/monthly", enterpriseAccountID), o, lr)
 }
 
 // Filters are special endpoints to allow for API consumers to specify a
@@ -2292,7 +2283,6 @@ type FilterAppsAppsOpts struct {
 		ID []*string `json:"id,omitempty" url:"id,omitempty,key"`
 	} `json:"in,omitempty" url:"in,omitempty,key"`
 }
-
 type FilterAppsAppsResult []struct {
 	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
 	BuildStack struct {
@@ -2401,7 +2391,8 @@ func (s *Service) FormationUpdate(ctx context.Context, appIdentity string, forma
 	return &formation, s.Patch(ctx, &formation, fmt.Sprintf("/apps/%v/formation/%v", appIdentity, formationIdentity), o)
 }
 
-// Identity Providers represent the SAML configuration of an Team.
+// Identity Providers represent the SAML configuration of an Enterprise
+// Account or Team.
 type IdentityProvider struct {
 	Certificate  string    `json:"certificate" url:"certificate,key"` // raw contents of the public certificate (eg: .crt or .pem file)
 	CreatedAt    time.Time `json:"created_at" url:"created_at,key"`   // when provider record was created
@@ -2618,7 +2609,6 @@ type LogDrain struct {
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when log drain was updated
 	URL       string    `json:"url" url:"url,key"`               // url associated with the log drain
 }
-
 type LogDrainCreateOpts struct {
 	URL string `json:"url" url:"url,key"` // url associated with the log drain
 }
@@ -2675,7 +2665,6 @@ type LogSession struct {
 	LogplexURL string    `json:"logplex_url" url:"logplex_url,key"` // URL for log streaming session
 	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when log session was updated
 }
-
 type LogSessionCreateOpts struct {
 	Dyno   *string `json:"dyno,omitempty" url:"dyno,omitempty,key"`     // dyno to limit results to
 	Lines  *int    `json:"lines,omitempty" url:"lines,omitempty,key"`   // number of log lines to stream at once
@@ -2726,7 +2715,6 @@ type OAuthAuthorization struct {
 		ID       string  `json:"id" url:"id,key"`               // unique identifier of an account
 	} `json:"user" url:"user,key"` // authenticated user associated with this authorization
 }
-
 type OAuthAuthorizationCreateOpts struct {
 	Client      *string `json:"client,omitempty" url:"client,omitempty,key"`           // unique identifier of this OAuth client
 	Description *string `json:"description,omitempty" url:"description,omitempty,key"` // human-friendly description of this OAuth authorization
@@ -2781,7 +2769,6 @@ type OAuthClient struct {
 	Secret            string    `json:"secret" url:"secret,key"`                         // secret used to obtain OAuth authorizations under this client
 	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                 // when OAuth client was updated
 }
-
 type OAuthClientCreateOpts struct {
 	Name        string `json:"name" url:"name,key"`                 // OAuth client name
 	RedirectURI string `json:"redirect_uri" url:"redirect_uri,key"` // endpoint for redirection after authorization with OAuth client
@@ -2873,7 +2860,6 @@ type OAuthToken struct {
 		ID string `json:"id" url:"id,key"` // unique identifier of an account
 	} `json:"user" url:"user,key"` // Reference to the user associated with this token
 }
-
 type OAuthTokenCreateOpts struct {
 	Client struct {
 		Secret *string `json:"secret,omitempty" url:"secret,omitempty,key"` // secret used to obtain OAuth authorizations under this client
@@ -2965,7 +2951,6 @@ type PasswordReset struct {
 		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
 	} `json:"user" url:"user,key"`
 }
-
 type PasswordResetResetPasswordOpts struct {
 	Email *string `json:"email,omitempty" url:"email,omitempty,key"` // unique email address of account
 }
@@ -3079,7 +3064,6 @@ type Pipeline struct {
 	} `json:"owner" url:"owner,key"` // Owner of a pipeline.
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline was updated
 }
-
 type PipelineCreateOpts struct {
 	Name  string `json:"name" url:"name,key"` // name of pipeline
 	Owner *struct {
@@ -3170,10 +3154,8 @@ func (s *Service) PipelineBuildList(ctx context.Context, pipelineID string, lr *
 
 // Pipeline Config Vars allow you to manage the configuration
 // information provided to a pipeline.
-type (
-	PipelineConfigVar                 map[string]string
-	PipelineConfigVarInfoForAppResult map[string]*string
-)
+type PipelineConfigVar map[string]string
+type PipelineConfigVarInfoForAppResult map[string]*string
 
 // Get config-vars for a pipeline stage.
 func (s *Service) PipelineConfigVarInfoForApp(ctx context.Context, pipelineID string, pipelineCouplingStage string) (PipelineConfigVarInfoForAppResult, error) {
@@ -3330,7 +3312,6 @@ type PipelinePromotion struct {
 	Status    string     `json:"status" url:"status,key"`         // status of promotion
 	UpdatedAt *time.Time `json:"updated_at" url:"updated_at,key"` // when promotion was updated
 }
-
 type PipelinePromotionCreateOpts struct {
 	Pipeline struct {
 		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
@@ -3450,7 +3431,6 @@ type PipelineTransfer struct {
 		Type string `json:"type" url:"type,key"` // type of pipeline owner
 	} `json:"previous_owner" url:"previous_owner,key"` // Owner of a pipeline.
 }
-
 type PipelineTransferCreateOpts struct {
 	NewOwner struct {
 		ID   *string `json:"id,omitempty" url:"id,omitempty,key"`     // unique identifier of a pipeline owner
@@ -3647,7 +3627,6 @@ type ReviewApp struct {
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"`   // when review app was updated
 	WaitForCi bool      `json:"wait_for_ci" url:"wait_for_ci,key"` // wait for ci before building the app
 }
-
 type ReviewAppCreateOpts struct {
 	Branch      string             `json:"branch" url:"branch,key"`                                 // the branch of the repository which the review app is based on
 	Environment map[string]*string `json:"environment,omitempty" url:"environment,omitempty,key"`   // hash of config vars
@@ -3703,17 +3682,14 @@ type ReviewAppConfig struct {
 	} `json:"deploy_target" url:"deploy_target,key"` // the deploy target for the review apps of a pipeline
 	DestroyStaleApps bool `json:"destroy_stale_apps" url:"destroy_stale_apps,key"` // automatically destroy review apps when they haven't been deployed for
 	// a number of days
-	Pipeline *struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
-	} `json:"pipeline" url:"pipeline,key"` // the pipeline associated with the review app
-	Repo struct {
+	PipelineID string `json:"pipeline_id" url:"pipeline_id,key"` // unique identifier of pipeline
+	Repo       struct {
 		ID int `json:"id" url:"id,key"` // repository id
 	} `json:"repo" url:"repo,key"`
 	StaleDays int `json:"stale_days" url:"stale_days,key"` // number of days without a deployment after which to consider a review
 	// app stale
 	WaitForCi bool `json:"wait_for_ci" url:"wait_for_ci,key"` // If true, review apps are created only when CI passes
 }
-
 type ReviewAppConfigEnableOpts struct {
 	AutomaticReviewApps *bool   `json:"automatic_review_apps,omitempty" url:"automatic_review_apps,omitempty,key"` // enable automatic review apps for pull requests
 	BaseName            *string `json:"base_name,omitempty" url:"base_name,omitempty,key"`                         // A unique prefix that will be used to create review app names
@@ -3865,7 +3841,6 @@ type SniEndpoint struct {
 	} `json:"ssl_cert" url:"ssl_cert,key"` // certificate provided by this endpoint
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when SNI endpoint was updated
 }
-
 type SniEndpointCreateOpts struct {
 	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
 	PrivateKey       string `json:"private_key" url:"private_key,key"`             // contents of the private key (eg .key file)
@@ -3992,11 +3967,12 @@ type SpaceCreateOpts struct {
 	DataCIDR *string `json:"data_cidr,omitempty" url:"data_cidr,omitempty,key"` // The RFC-1918 CIDR that the Private Space will use for the
 	// Heroku-managed peering connection that's automatically created when
 	// using Heroku Data add-ons. It must be between a /16 and a /20
-	Name        string  `json:"name" url:"name,key"`                             // unique name of space
-	Region      *string `json:"region,omitempty" url:"region,omitempty,key"`     // unique identifier of region
-	Shield      *bool   `json:"shield,omitempty" url:"shield,omitempty,key"`     // true if this space has shield enabled
-	Team        string  `json:"team" url:"team,key"`                             // unique name of team
-	LogDrainURL string  `json:"log_drain_url" url:"log_drain_url,omitempty,key"` // drain url for Private Space Logging
+	LogDrainURL *string `json:"log_drain_url,omitempty" url:"log_drain_url,omitempty,key"` // URL to which all apps will drain logs. Only settable during space
+	// creation and enables direct logging. Must use HTTPS.
+	Name   string  `json:"name" url:"name,key"`                         // unique name of space
+	Region *string `json:"region,omitempty" url:"region,omitempty,key"` // unique identifier of region
+	Shield *bool   `json:"shield,omitempty" url:"shield,omitempty,key"` // true if this space has shield enabled
+	Team   string  `json:"team" url:"team,key"`                         // unique name of team
 }
 
 // Create a new space.
@@ -4099,7 +4075,6 @@ type SpaceTransfer struct{}
 type SpaceTransferTransferOpts struct {
 	NewOwner string `json:"new_owner" url:"new_owner,key"` // unique name of team
 }
-
 type SpaceTransferTransferResult struct {
 	CIDR string `json:"cidr" url:"cidr,key"` // The RFC-1918 CIDR the Private Space will use. It must be a /16 in
 	// 10.0.0.0/8, 172.16.0.0/12 or 192.168.0.0/16
@@ -4159,7 +4134,6 @@ type SSLEndpoint struct {
 	} `json:"ssl_cert" url:"ssl_cert,key"` // certificate provided by this endpoint
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when endpoint was updated
 }
-
 type SSLEndpointCreateOpts struct {
 	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"`       // raw contents of the public certificate chain (eg: .crt or .pem file)
 	Preprocess       *bool  `json:"preprocess,omitempty" url:"preprocess,omitempty,key"` // allow Heroku to modify an uploaded public certificate chain if deemed
@@ -4245,8 +4219,13 @@ type Team struct {
 	} `json:"enterprise_account" url:"enterprise_account,key"`
 	ID               string `json:"id" url:"id,key"` // unique identifier of team
 	IdentityProvider *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this identity provider
-		Slug string `json:"slug" url:"slug,key"` // user-friendly unique identifier for this identity provider
+		ID    string `json:"id" url:"id,key"`     // unique identifier of this identity provider
+		Name  string `json:"name" url:"name,key"` // user-friendly unique identifier for this identity provider
+		Owner struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of the owner
+			Name string `json:"name" url:"name,key"` // name of the owner
+			Type string `json:"type" url:"type,key"` // type of the owner
+		} `json:"owner" url:"owner,key"` // entity that owns this identity provider
 	} `json:"identity_provider" url:"identity_provider,key"` // Identity Provider associated with the Team
 	MembershipLimit     *float64  `json:"membership_limit" url:"membership_limit,key"`         // upper limit of members allowed in a team.
 	Name                string    `json:"name" url:"name,key"`                                 // unique name of team
@@ -4329,42 +4308,40 @@ func (s *Service) TeamCreateInEnterpriseAccount(ctx context.Context, enterpriseA
 	return &team, s.Post(ctx, &team, fmt.Sprintf("/enterprise-accounts/%v/teams", enterpriseAccountIdentity), o)
 }
 
-type (
-	TeamAddOn                  struct{}
-	TeamAddOnListForTeamResult []struct {
-		Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
-		AddonService struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
-			Name string `json:"name" url:"name,key"` // unique name of this add-on-service
-		} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
-		App struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of app
-			Name string `json:"name" url:"name,key"` // unique name of app
-		} `json:"app" url:"app,key"` // billing application associated with this add-on
-		BilledPrice *struct {
-			Cents    int    `json:"cents" url:"cents,key"`       // price in cents per unit of plan
-			Contract bool   `json:"contract" url:"contract,key"` // price is negotiated in a contract outside of monthly add-on billing
-			Unit     string `json:"unit" url:"unit,key"`         // unit of price for plan
-		} `json:"billed_price" url:"billed_price,key"` // billed price
-		BillingEntity struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of the billing entity
-			Name string `json:"name" url:"name,key"` // name of the billing entity
-			Type string `json:"type" url:"type,key"` // type of Object of the billing entity; new types allowed at any time.
-		} `json:"billing_entity" url:"billing_entity,key"` // billing entity associated with this add-on
-		ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
-		CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
-		ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
-		Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
-		Plan       struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
-			Name string `json:"name" url:"name,key"` // unique name of this plan
-		} `json:"plan" url:"plan,key"` // identity of add-on plan
-		ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
-		State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
-		UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
-		WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
-	}
-)
+type TeamAddOn struct{}
+type TeamAddOnListForTeamResult []struct {
+	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
+	AddonService struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
+		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // billing application associated with this add-on
+	BilledPrice *struct {
+		Cents    int    `json:"cents" url:"cents,key"`       // price in cents per unit of plan
+		Contract bool   `json:"contract" url:"contract,key"` // price is negotiated in a contract outside of monthly add-on billing
+		Unit     string `json:"unit" url:"unit,key"`         // unit of price for plan
+	} `json:"billed_price" url:"billed_price,key"` // billed price
+	BillingEntity struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of the billing entity
+		Name string `json:"name" url:"name,key"` // name of the billing entity
+		Type string `json:"type" url:"type,key"` // type of Object of the billing entity; new types allowed at any time.
+	} `json:"billing_entity" url:"billing_entity,key"` // billing entity associated with this add-on
+	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
+	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
+	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
+	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
+	Plan       struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+		Name string `json:"name" url:"name,key"` // unique name of this plan
+	} `json:"plan" url:"plan,key"` // identity of add-on plan
+	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
+	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
+	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
+	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
+}
 
 // List add-ons used across all Team apps
 func (s *Service) TeamAddOnListForTeam(ctx context.Context, teamIdentity string, lr *ListRange) (TeamAddOnListForTeamResult, error) {
@@ -4414,7 +4391,6 @@ type TeamApp struct {
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
 	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
-
 type TeamAppCreateOpts struct {
 	InternalRouting *bool   `json:"internal_routing,omitempty" url:"internal_routing,omitempty,key"` // describes whether a Private Spaces app is externally routable or not
 	Locked          *bool   `json:"locked,omitempty" url:"locked,omitempty,key"`                     // are other team members forbidden from joining this app.
@@ -4500,7 +4476,6 @@ type TeamAppCollaborator struct {
 		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
 	} `json:"user" url:"user,key"` // identity of collaborated account
 }
-
 type TeamAppCollaboratorCreateOpts struct {
 	Permissions []*string `json:"permissions,omitempty" url:"permissions,omitempty,key"` // An array of permissions to give to the collaborator.
 	Silent      *bool     `json:"silent,omitempty" url:"silent,omitempty,key"`           // whether to suppress email invitation when creating collaborator
@@ -4579,16 +4554,22 @@ type TeamDailyUsage struct {
 	Partner float64 `json:"partner" url:"partner,key"` // total add-on credits used for third party add-ons
 	Space   float64 `json:"space" url:"space,key"`     // space credits used
 }
+type TeamDailyUsageInfoOpts struct {
+	End   *string `json:"end,omitempty" url:"end,omitempty,key"` // range end date
+	Start string  `json:"start" url:"start,key"`                 // range start date
+}
 type TeamDailyUsageInfoResult []TeamDailyUsage
 
 // Retrieves usage for an enterprise team for a range of days. Start and
-// end dates can be specified as query parameters using the date format,
-// YYYY-MM-DD format. For example,
-// '/teams/example-team/usage/daily?start=2019-01-01&end=2019-01-31'
-// specifies all days in January for 2019.
-func (s *Service) TeamDailyUsageInfo(ctx context.Context, teamID string, lr *ListRange) (TeamDailyUsageInfoResult, error) {
+// end dates can be specified as query parameters using the date format
+// YYYY-MM-DD.
+// The team identifier can be found from the [team list
+// endpoint](https://devcenter.heroku.com/articles/platform-api-reference
+// #team-list).
+//
+func (s *Service) TeamDailyUsageInfo(ctx context.Context, teamID string, o TeamDailyUsageInfoOpts, lr *ListRange) (TeamDailyUsageInfoResult, error) {
 	var teamDailyUsage TeamDailyUsageInfoResult
-	return teamDailyUsage, s.Get(ctx, &teamDailyUsage, fmt.Sprintf("/teams/%v/usage/daily", teamID), nil, lr)
+	return teamDailyUsage, s.Get(ctx, &teamDailyUsage, fmt.Sprintf("/teams/%v/usage/daily", teamID), o, lr)
 }
 
 // A team feature represents a feature enabled on a team account.
@@ -4764,7 +4745,6 @@ type TeamMember struct {
 		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
 	} `json:"user" url:"user,key"` // user information for the membership
 }
-
 type TeamMemberCreateOrUpdateOpts struct {
 	Email     string `json:"email" url:"email,key"`                             // email address of the team member
 	Federated *bool  `json:"federated,omitempty" url:"federated,omitempty,key"` // whether the user is federated and belongs to an Identity Provider
@@ -4881,17 +4861,22 @@ type TeamMonthlyUsage struct {
 	Partner float64 `json:"partner" url:"partner,key"` // total add-on credits used for third party add-ons
 	Space   float64 `json:"space" url:"space,key"`     // space credits used
 }
+type TeamMonthlyUsageInfoOpts struct {
+	End   *string `json:"end,omitempty" url:"end,omitempty,key"` // range end date
+	Start string  `json:"start" url:"start,key"`                 // range start date
+}
 type TeamMonthlyUsageInfoResult []TeamMonthlyUsage
 
 // Retrieves usage for an enterprise team for a range of months. Start
-// and end dates can be specified as query parameters using the date
-// format, YYYY-MM format. For example,
-// '/teams/example-team/usage/monthly?start=2019-01&end=2019-02'
-// specifies usage in January and February for 2019. If no end date is
-// specified, one month of usage is returned.
-func (s *Service) TeamMonthlyUsageInfo(ctx context.Context, teamID string, lr *ListRange) (TeamMonthlyUsageInfoResult, error) {
+// and end dates can be specified as query parameters using the date,
+// YYYY-MM. If no end date is specified, one month of usage is returned.
+// The team identifier can be found from the [team list
+// endpoint](https://devcenter.heroku.com/articles/platform-api-reference
+// #team-list).
+//
+func (s *Service) TeamMonthlyUsageInfo(ctx context.Context, teamID string, o TeamMonthlyUsageInfoOpts, lr *ListRange) (TeamMonthlyUsageInfoResult, error) {
 	var teamMonthlyUsage TeamMonthlyUsageInfoResult
-	return teamMonthlyUsage, s.Get(ctx, &teamMonthlyUsage, fmt.Sprintf("/teams/%v/usage/monthly", teamID), nil, lr)
+	return teamMonthlyUsage, s.Get(ctx, &teamMonthlyUsage, fmt.Sprintf("/teams/%v/usage/monthly", teamID), o, lr)
 }
 
 // Tracks a Team's Preferences
@@ -5032,12 +5017,10 @@ type TestRun struct {
 	Status        string    `json:"status" url:"status,key"`                   // current state of the test run
 	UpdatedAt     time.Time `json:"updated_at" url:"updated_at,key"`           // when test-run was updated
 	User          struct {
-		AcknowledgedMsa     bool       `json:"acknowledged_msa" url:"acknowledged_msa,key"`         // deprecated. whether account has acknowledged the MSA terms of service
-		AcknowledgedMsaAt   *time.Time `json:"acknowledged_msa_at" url:"acknowledged_msa_at,key"`   // deprecated. when account has acknowledged the MSA terms of service
-		AllowTracking       bool       `json:"allow_tracking" url:"allow_tracking,key"`             // whether to allow third party web activity tracking
-		Beta                bool       `json:"beta" url:"beta,key"`                                 // whether allowed to utilize beta Heroku features
-		CountryOfResidence  *string    `json:"country_of_residence" url:"country_of_residence,key"` // country where account owner resides
-		CreatedAt           time.Time  `json:"created_at" url:"created_at,key"`                     // when account was created
+		AllowTracking       bool      `json:"allow_tracking" url:"allow_tracking,key"`             // whether to allow third party web activity tracking
+		Beta                bool      `json:"beta" url:"beta,key"`                                 // whether allowed to utilize beta Heroku features
+		CountryOfResidence  *string   `json:"country_of_residence" url:"country_of_residence,key"` // country where account owner resides
+		CreatedAt           time.Time `json:"created_at" url:"created_at,key"`                     // when account was created
 		DefaultOrganization *struct {
 			ID   string `json:"id" url:"id,key"`     // unique identifier of team
 			Name string `json:"name" url:"name,key"` // unique name of team
@@ -5051,7 +5034,8 @@ type TestRun struct {
 		Federated        bool       `json:"federated" url:"federated,key"`         // whether the user is federated and belongs to an Identity Provider
 		ID               string     `json:"id" url:"id,key"`                       // unique identifier of an account
 		IdentityProvider *struct {
-			ID           string `json:"id" url:"id,key"` // unique identifier of this identity provider
+			ID           string `json:"id" url:"id,key"`     // unique identifier of this identity provider
+			Name         string `json:"name" url:"name,key"` // user-friendly unique identifier for this identity provider
 			Organization struct {
 				Name string `json:"name" url:"name,key"` // unique name of team
 			} `json:"organization" url:"organization,key"`
@@ -5064,10 +5048,6 @@ type TestRun struct {
 				Name string `json:"name" url:"name,key"` // unique name of team
 			} `json:"team" url:"team,key"`
 		} `json:"identity_provider" url:"identity_provider,key"` // Identity Provider details for federated users.
-		ItalianCustomerTerms *string `json:"italian_customer_terms" url:"italian_customer_terms,key"` // deprecated. whether account has acknowledged the Italian customer
-		// terms of service
-		ItalianPartnerTerms *string `json:"italian_partner_terms" url:"italian_partner_terms,key"` // deprecated. whether account has acknowledged the Italian provider
-		// terms of service
 		LastLogin               *time.Time `json:"last_login" url:"last_login,key"`                               // when account last authorized with Heroku
 		Name                    *string    `json:"name" url:"name,key"`                                           // full name of the account owner
 		SmsNumber               *string    `json:"sms_number" url:"sms_number,key"`                               // SMS number of account
@@ -5079,7 +5059,6 @@ type TestRun struct {
 	// platform.
 	WarningMessage *string `json:"warning_message" url:"warning_message,key"` // human friently warning emitted during the test run
 }
-
 type TestRunCreateOpts struct {
 	CommitBranch  string  `json:"commit_branch" url:"commit_branch,key"`                   // the branch of the repository that the test run concerns
 	CommitMessage string  `json:"commit_message" url:"commit_message,key"`                 // the message for the commit under test
@@ -5190,7 +5169,6 @@ type VPNConnection struct {
 		StatusMessage    string `json:"status_message" url:"status_message,key"`         // Details of the status
 	} `json:"tunnels" url:"tunnels,key"`
 }
-
 type VPNConnectionCreateOpts struct {
 	Name          string   `json:"name" url:"name,key"`                     // VPN Name
 	PublicIP      string   `json:"public_ip" url:"public_ip,key"`           // Public IP of VPN customer gateway

--- a/v5/heroku.go
+++ b/v5/heroku.go
@@ -15,13 +15,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/google/go-querystring/query"
 	"io"
 	"net/http"
 	"reflect"
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/google/go-querystring/query"
 )
 
 var _ = time.Second
@@ -580,6 +581,7 @@ type AddOnAttachment struct {
 	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`       // when add-on attachment was updated
 	WebURL      *string   `json:"web_url" url:"web_url,key"`             // URL for logging into web interface of add-on in attached app context
 }
+
 type AddOnAttachmentCreateOpts struct {
 	Addon     string  `json:"addon" url:"addon,key"`                             // unique identifier of add-on
 	App       string  `json:"app" url:"app,key"`                                 // unique identifier of app
@@ -793,6 +795,7 @@ type AddOnWebhook struct {
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the webhook was updated
 	URL       string    `json:"url" url:"url,key"`               // the URL where the webhook's notification requests are sent
 }
+
 type AddOnWebhookCreateOpts struct {
 	Authorization *string `json:"authorization,omitempty" url:"authorization,omitempty,key"` // a custom `Authorization` header that Heroku will include with all
 	// webhook notifications
@@ -805,6 +808,7 @@ type AddOnWebhookCreateOpts struct {
 	// `Heroku-Webhook-Hmac-SHA256` header)
 	URL string `json:"url" url:"url,key"` // the URL where the webhook's notification requests are sent
 }
+
 type AddOnWebhookCreateResult struct {
 	Addon struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
@@ -905,6 +909,7 @@ type AddOnWebhookUpdateOpts struct {
 	// `Heroku-Webhook-Hmac-SHA256` header)
 	URL *string `json:"url,omitempty" url:"url,omitempty,key"` // the URL where the webhook's notification requests are sent
 }
+
 type AddOnWebhookUpdateResult struct {
 	Addon struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
@@ -1136,6 +1141,7 @@ type App struct {
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
 	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
+
 type AppCreateOpts struct {
 	Name   *string `json:"name,omitempty" url:"name,omitempty,key"`     // unique name of app
 	Region *string `json:"region,omitempty" url:"region,omitempty,key"` // unique identifier of region
@@ -1286,6 +1292,7 @@ type AppSetup struct {
 	Status             string    `json:"status" url:"status,key"`                             // the overall status of app setup
 	UpdatedAt          time.Time `json:"updated_at" url:"updated_at,key"`                     // when app setup was updated
 }
+
 type AppSetupCreateOpts struct {
 	App *struct {
 		Locked       *bool   `json:"locked,omitempty" url:"locked,omitempty,key"`             // are other team members forbidden from joining this app.
@@ -1345,6 +1352,7 @@ type AppTransfer struct {
 	State     string    `json:"state" url:"state,key"`           // the current state of an app transfer
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app transfer was updated
 }
+
 type AppTransferCreateOpts struct {
 	App       string `json:"app" url:"app,key"`                           // unique identifier of app
 	Recipient string `json:"recipient" url:"recipient,key"`               // unique email address of account
@@ -1401,6 +1409,7 @@ type AppWebhookCreateOpts struct {
 	// `Heroku-Webhook-Hmac-SHA256` header)
 	URL string `json:"url" url:"url,key"` // the URL where the webhook's notification requests are sent
 }
+
 type AppWebhookCreateResult struct {
 	App struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of app
@@ -1497,6 +1506,7 @@ type AppWebhookUpdateOpts struct {
 	// `Heroku-Webhook-Hmac-SHA256` header)
 	URL *string `json:"url,omitempty" url:"url,omitempty,key"` // the URL where the webhook's notification requests are sent
 }
+
 type AppWebhookUpdateResult struct {
 	App struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of app
@@ -1699,6 +1709,7 @@ type Build struct {
 		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
 	} `json:"user" url:"user,key"` // user that started the build
 }
+
 type BuildCreateOpts struct {
 	Buildpacks []*struct {
 		Name *string `json:"name,omitempty" url:"name,omitempty,key"` // Buildpack Registry name of the buildpack for the app
@@ -1750,6 +1761,7 @@ type BuildpackInstallation struct {
 	} `json:"buildpack" url:"buildpack,key"` // buildpack
 	Ordinal int `json:"ordinal" url:"ordinal,key"` // determines the order in which the buildpacks will execute
 }
+
 type BuildpackInstallationUpdateOpts struct {
 	Updates []struct {
 		Buildpack string `json:"buildpack" url:"buildpack,key"` // location of the buildpack for the app. Either a url (unofficial
@@ -1793,6 +1805,7 @@ type Collaborator struct {
 		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
 	} `json:"user" url:"user,key"` // identity of collaborated account
 }
+
 type CollaboratorCreateOpts struct {
 	Silent *bool  `json:"silent,omitempty" url:"silent,omitempty,key"` // whether to suppress email invitation when creating collaborator
 	User   string `json:"user" url:"user,key"`                         // unique email address of account
@@ -1826,8 +1839,10 @@ func (s *Service) CollaboratorList(ctx context.Context, appIdentity string, lr *
 
 // Config Vars allow you to manage the configuration information
 // provided to an app on Heroku.
-type ConfigVar map[string]string
-type ConfigVarInfoForAppResult map[string]*string
+type (
+	ConfigVar                 map[string]string
+	ConfigVarInfoForAppResult map[string]*string
+)
 
 // Get config-vars for app.
 func (s *Service) ConfigVarInfoForApp(ctx context.Context, appIdentity string) (ConfigVarInfoForAppResult, error) {
@@ -1863,6 +1878,7 @@ type Credit struct {
 	Title     string    `json:"title" url:"title,key"`           // a name for credit
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when credit was updated
 }
+
 type CreditCreateOpts struct {
 	Code1 *string `json:"code1,omitempty" url:"code1,omitempty,key"` // first code from a discount card
 	Code2 *string `json:"code2,omitempty" url:"code2,omitempty,key"` // second code from a discount card
@@ -1908,6 +1924,7 @@ type Domain struct {
 	Status    string    `json:"status" url:"status,key"`         // status of this record's cname
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when domain was updated
 }
+
 type DomainCreateDeprecatedOpts struct {
 	Hostname string `json:"hostname" url:"hostname,key"` // full hostname
 }
@@ -1988,6 +2005,7 @@ type Dyno struct {
 	Type      string    `json:"type" url:"type,key"`             // type of process
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when process last changed state
 }
+
 type DynoCreateOpts struct {
 	Attach     *bool             `json:"attach,omitempty" url:"attach,omitempty,key"`             // whether to stream output or not
 	Command    string            `json:"command" url:"command,key"`                               // command used to start this process
@@ -2274,6 +2292,7 @@ type FilterAppsAppsOpts struct {
 		ID []*string `json:"id,omitempty" url:"id,omitempty,key"`
 	} `json:"in,omitempty" url:"in,omitempty,key"`
 }
+
 type FilterAppsAppsResult []struct {
 	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
 	BuildStack struct {
@@ -2599,6 +2618,7 @@ type LogDrain struct {
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when log drain was updated
 	URL       string    `json:"url" url:"url,key"`               // url associated with the log drain
 }
+
 type LogDrainCreateOpts struct {
 	URL string `json:"url" url:"url,key"` // url associated with the log drain
 }
@@ -2655,6 +2675,7 @@ type LogSession struct {
 	LogplexURL string    `json:"logplex_url" url:"logplex_url,key"` // URL for log streaming session
 	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when log session was updated
 }
+
 type LogSessionCreateOpts struct {
 	Dyno   *string `json:"dyno,omitempty" url:"dyno,omitempty,key"`     // dyno to limit results to
 	Lines  *int    `json:"lines,omitempty" url:"lines,omitempty,key"`   // number of log lines to stream at once
@@ -2705,6 +2726,7 @@ type OAuthAuthorization struct {
 		ID       string  `json:"id" url:"id,key"`               // unique identifier of an account
 	} `json:"user" url:"user,key"` // authenticated user associated with this authorization
 }
+
 type OAuthAuthorizationCreateOpts struct {
 	Client      *string `json:"client,omitempty" url:"client,omitempty,key"`           // unique identifier of this OAuth client
 	Description *string `json:"description,omitempty" url:"description,omitempty,key"` // human-friendly description of this OAuth authorization
@@ -2759,6 +2781,7 @@ type OAuthClient struct {
 	Secret            string    `json:"secret" url:"secret,key"`                         // secret used to obtain OAuth authorizations under this client
 	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                 // when OAuth client was updated
 }
+
 type OAuthClientCreateOpts struct {
 	Name        string `json:"name" url:"name,key"`                 // OAuth client name
 	RedirectURI string `json:"redirect_uri" url:"redirect_uri,key"` // endpoint for redirection after authorization with OAuth client
@@ -2850,6 +2873,7 @@ type OAuthToken struct {
 		ID string `json:"id" url:"id,key"` // unique identifier of an account
 	} `json:"user" url:"user,key"` // Reference to the user associated with this token
 }
+
 type OAuthTokenCreateOpts struct {
 	Client struct {
 		Secret *string `json:"secret,omitempty" url:"secret,omitempty,key"` // secret used to obtain OAuth authorizations under this client
@@ -2941,6 +2965,7 @@ type PasswordReset struct {
 		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
 	} `json:"user" url:"user,key"`
 }
+
 type PasswordResetResetPasswordOpts struct {
 	Email *string `json:"email,omitempty" url:"email,omitempty,key"` // unique email address of account
 }
@@ -3054,6 +3079,7 @@ type Pipeline struct {
 	} `json:"owner" url:"owner,key"` // Owner of a pipeline.
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline was updated
 }
+
 type PipelineCreateOpts struct {
 	Name  string `json:"name" url:"name,key"` // name of pipeline
 	Owner *struct {
@@ -3144,8 +3170,10 @@ func (s *Service) PipelineBuildList(ctx context.Context, pipelineID string, lr *
 
 // Pipeline Config Vars allow you to manage the configuration
 // information provided to a pipeline.
-type PipelineConfigVar map[string]string
-type PipelineConfigVarInfoForAppResult map[string]*string
+type (
+	PipelineConfigVar                 map[string]string
+	PipelineConfigVarInfoForAppResult map[string]*string
+)
 
 // Get config-vars for a pipeline stage.
 func (s *Service) PipelineConfigVarInfoForApp(ctx context.Context, pipelineID string, pipelineCouplingStage string) (PipelineConfigVarInfoForAppResult, error) {
@@ -3302,6 +3330,7 @@ type PipelinePromotion struct {
 	Status    string     `json:"status" url:"status,key"`         // status of promotion
 	UpdatedAt *time.Time `json:"updated_at" url:"updated_at,key"` // when promotion was updated
 }
+
 type PipelinePromotionCreateOpts struct {
 	Pipeline struct {
 		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
@@ -3421,6 +3450,7 @@ type PipelineTransfer struct {
 		Type string `json:"type" url:"type,key"` // type of pipeline owner
 	} `json:"previous_owner" url:"previous_owner,key"` // Owner of a pipeline.
 }
+
 type PipelineTransferCreateOpts struct {
 	NewOwner struct {
 		ID   *string `json:"id,omitempty" url:"id,omitempty,key"`     // unique identifier of a pipeline owner
@@ -3617,6 +3647,7 @@ type ReviewApp struct {
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"`   // when review app was updated
 	WaitForCi bool      `json:"wait_for_ci" url:"wait_for_ci,key"` // wait for ci before building the app
 }
+
 type ReviewAppCreateOpts struct {
 	Branch      string             `json:"branch" url:"branch,key"`                                 // the branch of the repository which the review app is based on
 	Environment map[string]*string `json:"environment,omitempty" url:"environment,omitempty,key"`   // hash of config vars
@@ -3682,6 +3713,7 @@ type ReviewAppConfig struct {
 	// app stale
 	WaitForCi bool `json:"wait_for_ci" url:"wait_for_ci,key"` // If true, review apps are created only when CI passes
 }
+
 type ReviewAppConfigEnableOpts struct {
 	AutomaticReviewApps *bool   `json:"automatic_review_apps,omitempty" url:"automatic_review_apps,omitempty,key"` // enable automatic review apps for pull requests
 	BaseName            *string `json:"base_name,omitempty" url:"base_name,omitempty,key"`                         // A unique prefix that will be used to create review app names
@@ -3833,6 +3865,7 @@ type SniEndpoint struct {
 	} `json:"ssl_cert" url:"ssl_cert,key"` // certificate provided by this endpoint
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when SNI endpoint was updated
 }
+
 type SniEndpointCreateOpts struct {
 	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
 	PrivateKey       string `json:"private_key" url:"private_key,key"`             // contents of the private key (eg .key file)
@@ -3959,10 +3992,11 @@ type SpaceCreateOpts struct {
 	DataCIDR *string `json:"data_cidr,omitempty" url:"data_cidr,omitempty,key"` // The RFC-1918 CIDR that the Private Space will use for the
 	// Heroku-managed peering connection that's automatically created when
 	// using Heroku Data add-ons. It must be between a /16 and a /20
-	Name   string  `json:"name" url:"name,key"`                         // unique name of space
-	Region *string `json:"region,omitempty" url:"region,omitempty,key"` // unique identifier of region
-	Shield *bool   `json:"shield,omitempty" url:"shield,omitempty,key"` // true if this space has shield enabled
-	Team   string  `json:"team" url:"team,key"`                         // unique name of team
+	Name        string  `json:"name" url:"name,key"`                             // unique name of space
+	Region      *string `json:"region,omitempty" url:"region,omitempty,key"`     // unique identifier of region
+	Shield      *bool   `json:"shield,omitempty" url:"shield,omitempty,key"`     // true if this space has shield enabled
+	Team        string  `json:"team" url:"team,key"`                             // unique name of team
+	LogDrainURL string  `json:"log_drain_url" url:"log_drain_url,omitempty,key"` // drain url for Private Space Logging
 }
 
 // Create a new space.
@@ -4065,6 +4099,7 @@ type SpaceTransfer struct{}
 type SpaceTransferTransferOpts struct {
 	NewOwner string `json:"new_owner" url:"new_owner,key"` // unique name of team
 }
+
 type SpaceTransferTransferResult struct {
 	CIDR string `json:"cidr" url:"cidr,key"` // The RFC-1918 CIDR the Private Space will use. It must be a /16 in
 	// 10.0.0.0/8, 172.16.0.0/12 or 192.168.0.0/16
@@ -4124,6 +4159,7 @@ type SSLEndpoint struct {
 	} `json:"ssl_cert" url:"ssl_cert,key"` // certificate provided by this endpoint
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when endpoint was updated
 }
+
 type SSLEndpointCreateOpts struct {
 	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"`       // raw contents of the public certificate chain (eg: .crt or .pem file)
 	Preprocess       *bool  `json:"preprocess,omitempty" url:"preprocess,omitempty,key"` // allow Heroku to modify an uploaded public certificate chain if deemed
@@ -4293,40 +4329,42 @@ func (s *Service) TeamCreateInEnterpriseAccount(ctx context.Context, enterpriseA
 	return &team, s.Post(ctx, &team, fmt.Sprintf("/enterprise-accounts/%v/teams", enterpriseAccountIdentity), o)
 }
 
-type TeamAddOn struct{}
-type TeamAddOnListForTeamResult []struct {
-	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
-	AddonService struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
-		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
-	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // billing application associated with this add-on
-	BilledPrice *struct {
-		Cents    int    `json:"cents" url:"cents,key"`       // price in cents per unit of plan
-		Contract bool   `json:"contract" url:"contract,key"` // price is negotiated in a contract outside of monthly add-on billing
-		Unit     string `json:"unit" url:"unit,key"`         // unit of price for plan
-	} `json:"billed_price" url:"billed_price,key"` // billed price
-	BillingEntity struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of the billing entity
-		Name string `json:"name" url:"name,key"` // name of the billing entity
-		Type string `json:"type" url:"type,key"` // type of Object of the billing entity; new types allowed at any time.
-	} `json:"billing_entity" url:"billing_entity,key"` // billing entity associated with this add-on
-	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
-	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
-	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
-	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
-	Plan       struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
-		Name string `json:"name" url:"name,key"` // unique name of this plan
-	} `json:"plan" url:"plan,key"` // identity of add-on plan
-	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
-	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
-	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
-	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
-}
+type (
+	TeamAddOn                  struct{}
+	TeamAddOnListForTeamResult []struct {
+		Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
+		AddonService struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
+			Name string `json:"name" url:"name,key"` // unique name of this add-on-service
+		} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
+		App struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of app
+			Name string `json:"name" url:"name,key"` // unique name of app
+		} `json:"app" url:"app,key"` // billing application associated with this add-on
+		BilledPrice *struct {
+			Cents    int    `json:"cents" url:"cents,key"`       // price in cents per unit of plan
+			Contract bool   `json:"contract" url:"contract,key"` // price is negotiated in a contract outside of monthly add-on billing
+			Unit     string `json:"unit" url:"unit,key"`         // unit of price for plan
+		} `json:"billed_price" url:"billed_price,key"` // billed price
+		BillingEntity struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of the billing entity
+			Name string `json:"name" url:"name,key"` // name of the billing entity
+			Type string `json:"type" url:"type,key"` // type of Object of the billing entity; new types allowed at any time.
+		} `json:"billing_entity" url:"billing_entity,key"` // billing entity associated with this add-on
+		ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
+		CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
+		ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
+		Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
+		Plan       struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+			Name string `json:"name" url:"name,key"` // unique name of this plan
+		} `json:"plan" url:"plan,key"` // identity of add-on plan
+		ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
+		State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
+		UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
+		WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
+	}
+)
 
 // List add-ons used across all Team apps
 func (s *Service) TeamAddOnListForTeam(ctx context.Context, teamIdentity string, lr *ListRange) (TeamAddOnListForTeamResult, error) {
@@ -4376,6 +4414,7 @@ type TeamApp struct {
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
 	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
+
 type TeamAppCreateOpts struct {
 	InternalRouting *bool   `json:"internal_routing,omitempty" url:"internal_routing,omitempty,key"` // describes whether a Private Spaces app is externally routable or not
 	Locked          *bool   `json:"locked,omitempty" url:"locked,omitempty,key"`                     // are other team members forbidden from joining this app.
@@ -4461,6 +4500,7 @@ type TeamAppCollaborator struct {
 		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
 	} `json:"user" url:"user,key"` // identity of collaborated account
 }
+
 type TeamAppCollaboratorCreateOpts struct {
 	Permissions []*string `json:"permissions,omitempty" url:"permissions,omitempty,key"` // An array of permissions to give to the collaborator.
 	Silent      *bool     `json:"silent,omitempty" url:"silent,omitempty,key"`           // whether to suppress email invitation when creating collaborator
@@ -4724,6 +4764,7 @@ type TeamMember struct {
 		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
 	} `json:"user" url:"user,key"` // user information for the membership
 }
+
 type TeamMemberCreateOrUpdateOpts struct {
 	Email     string `json:"email" url:"email,key"`                             // email address of the team member
 	Federated *bool  `json:"federated,omitempty" url:"federated,omitempty,key"` // whether the user is federated and belongs to an Identity Provider
@@ -5038,6 +5079,7 @@ type TestRun struct {
 	// platform.
 	WarningMessage *string `json:"warning_message" url:"warning_message,key"` // human friently warning emitted during the test run
 }
+
 type TestRunCreateOpts struct {
 	CommitBranch  string  `json:"commit_branch" url:"commit_branch,key"`                   // the branch of the repository that the test run concerns
 	CommitMessage string  `json:"commit_message" url:"commit_message,key"`                 // the message for the commit under test
@@ -5148,6 +5190,7 @@ type VPNConnection struct {
 		StatusMessage    string `json:"status_message" url:"status_message,key"`         // Details of the status
 	} `json:"tunnels" url:"tunnels,key"`
 }
+
 type VPNConnectionCreateOpts struct {
 	Name          string   `json:"name" url:"name,key"`                     // VPN Name
 	PublicIP      string   `json:"public_ip" url:"public_ip,key"`           // Public IP of VPN customer gateway

--- a/v5/schema.json
+++ b/v5/schema.json
@@ -368,46 +368,6 @@
           "type": [
             "boolean"
           ]
-        },
-        "acknowledged_msa": {
-          "deprecated": true,
-          "description": "deprecated. whether account has acknowledged the MSA terms of service",
-          "example": false,
-          "readOnly": true,
-          "type": [
-            "boolean"
-          ]
-        },
-        "acknowledged_msa_at": {
-          "deprecated": true,
-          "description": "deprecated. when account has acknowledged the MSA terms of service",
-          "example": "2012-01-01T12:00:00Z",
-          "format": "date-time",
-          "readOnly": true,
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "italian_customer_terms": {
-          "deprecated": true,
-          "description": "deprecated. whether account has acknowledged the Italian customer terms of service",
-          "example": "affirmatively_accepted",
-          "readOnly": true,
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "italian_partner_terms": {
-          "deprecated": true,
-          "description": "deprecated. whether account has acknowledged the Italian provider terms of service",
-          "example": "affirmatively_accepted",
-          "readOnly": true,
-          "type": [
-            "string",
-            "null"
-          ]
         }
       },
       "links": [
@@ -525,9 +485,13 @@
         },
         "identity_provider": {
           "description": "Identity Provider details for federated users.",
+          "strictProperties": true,
           "properties": {
             "id": {
               "$ref": "#/definitions/identity-provider/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/identity-provider/definitions/name"
             },
             "team": {
               "type": [
@@ -550,46 +514,7 @@
               }
             },
             "owner": {
-              "description": "entity that owns this identity provider",
-              "properties": {
-                "id": {
-                  "description": "unique identifier of the owner",
-                  "example": "01234567-89ab-cdef-0123-456789abcdef",
-                  "format": "uuid",
-                  "readOnly": true,
-                  "type": [
-                    "string"
-                  ]
-                },
-                "name": {
-                  "description": "name of the owner",
-                  "example": "acme",
-                  "readOnly": true,
-                  "type": [
-                    "string"
-                  ]
-                },
-                "type": {
-                  "description": "type of the owner",
-                  "enum": [
-                    "team",
-                    "enterprise-account"
-                  ],
-                  "example": "team",
-                  "readOnly": true,
-                  "type": [
-                    "string"
-                  ]
-                }
-              },
-              "readOnly": false,
-              "required": [
-                "id",
-                "type"
-              ],
-              "type": [
-                "object"
-              ]
+              "$ref": "#/definitions/identity-provider/definitions/owner"
             }
           },
           "type": [
@@ -620,18 +545,6 @@
         },
         "verified": {
           "$ref": "#/definitions/account/definitions/verified"
-        },
-        "acknowledged_msa": {
-          "$ref": "#/definitions/account/definitions/acknowledged_msa"
-        },
-        "acknowledged_msa_at": {
-          "$ref": "#/definitions/account/definitions/acknowledged_msa_at"
-        },
-        "italian_customer_terms": {
-          "$ref": "#/definitions/account/definitions/italian_customer_terms"
-        },
-        "italian_partner_terms": {
-          "$ref": "#/definitions/account/definitions/italian_partner_terms"
         },
         "country_of_residence": {
           "$ref": "#/definitions/account/definitions/country_of_residence"
@@ -4524,7 +4437,7 @@
       },
       "links": [
         {
-          "description": "List existing events. Returns all events for one date, defaulting to current date. Order, actor, action, and type, and date query params can be specified as query parameters. For example, '/enterprise-accounts/:id/events?order=desc&actor=user@example.com&action=create&type=app&date=2020-09-30' would return events in descending order and only return app created events by the user with user@example.com email address.",
+          "description": "List existing events. Returns all events for one day, defaulting to current day. Order, actor, action, and type, and day query params can be specified as query parameters. For example, '/enterprise-accounts/:id/events?order=desc&actor=user@example.com&action=create&type=app&day=2020-09-30' would return events in descending order and only return app created events by the user with user@example.com email address.",
           "href": "/enterprise-accounts/{(%23%2Fdefinitions%2Fenterprise-account%2Fdefinitions%2Fidentity)}/events",
           "method": "GET",
           "rel": "instances",
@@ -6249,15 +6162,49 @@
           "type": [
             "number"
           ]
+        },
+        "start_date": {
+          "description": "range start date",
+          "example": "2019-01-25",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "end_date": {
+          "description": "range end date",
+          "example": "2019-02-25",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
         }
       },
       "links": [
         {
-          "description": "Retrieves usage for an enterprise account for a range of days. Start and end dates can be specified as query parameters using the date format, YYYY-MM-DD format. For example, '/enterprise-accounts/example-account/usage/daily?start=2019-01-01&end=2019-01-31' specifies all days in January for 2019.",
+          "description": "Retrieves usage for an enterprise account for a range of days. Start and end dates can be specified as query parameters using the date format YYYY-MM-DD.\nThe enterprise account identifier can be found from the [enterprise account list](https://devcenter.heroku.com/articles/platform-api-reference#enterprise-account-list).\n",
           "href": "/enterprise-accounts/{(%23%2Fdefinitions%2Fenterprise-account%2Fdefinitions%2Fid)}/usage/daily",
           "method": "GET",
           "rel": "instances",
           "title": "Info",
+          "schema": {
+            "properties": {
+              "start": {
+                "$ref": "#/definitions/enterprise-account-daily-usage/definitions/start_date"
+              },
+              "end": {
+                "$ref": "#/definitions/enterprise-account-daily-usage/definitions/end_date"
+              }
+            },
+            "required": [
+              "start"
+            ],
+            "type": [
+              "object"
+            ]
+          },
           "targetSchema": {
             "items": {
               "$ref": "#/definitions/enterprise-account-daily-usage"
@@ -6674,15 +6621,49 @@
           "type": [
             "number"
           ]
+        },
+        "start_date": {
+          "description": "range start date",
+          "example": "2019-01",
+          "pattern": "^[0-9]{4}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "end_date": {
+          "description": "range end date",
+          "example": "2019-02",
+          "pattern": "^[0-9]{4}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
         }
       },
       "links": [
         {
-          "description": "Retrieves usage for an enterprise account for a range of months. Start and end dates can be specified as query parameters using the date format, YYYY-MM format. For example, '/enterprise-accounts/example-account/usage/monthly?start=2019-01&end=2019-02' specifies usage in January and February for 2019. If no end date is specified, one month of usage is returned.",
+          "description": "Retrieves usage for an enterprise account for a range of months. Start and end dates can be specified as query parameters using the date format YYYY-MM. If no end date is specified, one month of usage is returned.\nThe enterprise account identifier can be found from the [enterprise account list](https://devcenter.heroku.com/articles/platform-api-reference#enterprise-account-list).\n",
           "href": "/enterprise-accounts/{(%23%2Fdefinitions%2Fenterprise-account%2Fdefinitions%2Fid)}/usage/monthly",
           "method": "GET",
           "rel": "instances",
           "title": "Info",
+          "schema": {
+            "properties": {
+              "start": {
+                "$ref": "#/definitions/enterprise-account-monthly-usage/definitions/start_date"
+              },
+              "end": {
+                "$ref": "#/definitions/enterprise-account-monthly-usage/definitions/end_date"
+              }
+            },
+            "required": [
+              "start"
+            ],
+            "type": [
+              "object"
+            ]
+          },
           "targetSchema": {
             "items": {
               "$ref": "#/definitions/enterprise-account-monthly-usage"
@@ -6804,6 +6785,25 @@
             }
           ]
         },
+        "identity_provider": {
+          "description": "Identity Provider associated with the Enterprise Account",
+          "strictProperties": true,
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/identity-provider/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/identity-provider/definitions/name"
+            },
+            "owner": {
+              "$ref": "#/definitions/identity-provider/definitions/owner"
+            }
+          }
+        },
         "name": {
           "description": "unique name of the enterprise account",
           "example": "example",
@@ -6906,27 +6906,7 @@
           "$ref": "#/definitions/enterprise-account/definitions/trial"
         },
         "identity_provider": {
-          "description": "Identity Provider associated with the Enterprise Account",
-          "strictProperties": true,
-          "type": [
-            "null",
-            "object"
-          ],
-          "properties": {
-            "id": {
-              "$ref": "#/definitions/identity-provider/definitions/id"
-            },
-            "name": {
-              "description": "user-friendly unique identifier for this identity provider",
-              "example": "acme-sso",
-              "type": [
-                "string"
-              ]
-            },
-            "owner": {
-              "$ref": "#/definitions/identity-provider/definitions/owner"
-            }
-          }
+          "$ref": "#/definitions/enterprise-account/definitions/identity_provider"
         }
       }
     },
@@ -7223,7 +7203,7 @@
       }
     },
     "identity-provider": {
-      "description": "Identity Providers represent the SAML configuration of an Team.",
+      "description": "Identity Providers represent the SAML configuration of an Enterprise Account or Team.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "production",
       "strictProperties": true,
@@ -7262,6 +7242,13 @@
           "example": "01234567-89ab-cdef-0123-456789abcdef",
           "format": "uuid",
           "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "name": {
+          "description": "user-friendly unique identifier for this identity provider",
+          "example": "acme-sso",
           "type": [
             "string"
           ]
@@ -13352,6 +13339,13 @@
             "string"
           ]
         },
+        "log_drain_url": {
+          "description": "URL to which all apps will drain logs. Only settable during space creation and enables direct logging. Must use HTTPS.",
+          "example": "https://example.com/logs",
+          "type": [
+            "string"
+          ]
+        },
         "cidr": {
           "description": "The RFC-1918 CIDR the Private Space will use. It must be a /16 in 10.0.0.0/8, 172.16.0.0/12 or 192.168.0.0/16",
           "example": "172.20.20.30/16",
@@ -13451,6 +13445,9 @@
               },
               "data_cidr": {
                 "$ref": "#/definitions/space/definitions/data_cidr"
+              },
+              "log_drain_url": {
+                "$ref": "#/definitions/space/definitions/log_drain_url"
               }
             },
             "required": [
@@ -14651,14 +14648,48 @@
           "type": [
             "number"
           ]
+        },
+        "start_date": {
+          "description": "range start date",
+          "example": "2019-01-25",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "end_date": {
+          "description": "range end date",
+          "example": "2019-02-25",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
         }
       },
       "links": [
         {
-          "description": "Retrieves usage for an enterprise team for a range of days. Start and end dates can be specified as query parameters using the date format, YYYY-MM-DD format. For example, '/teams/example-team/usage/daily?start=2019-01-01&end=2019-01-31' specifies all days in January for 2019.",
+          "description": "Retrieves usage for an enterprise team for a range of days. Start and end dates can be specified as query parameters using the date format YYYY-MM-DD.\nThe team identifier can be found from the [team list endpoint](https://devcenter.heroku.com/articles/platform-api-reference#team-list).\n",
           "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fid)}/usage/daily",
           "method": "GET",
           "title": "Info",
+          "schema": {
+            "properties": {
+              "start": {
+                "$ref": "#/definitions/team-daily-usage/definitions/start_date"
+              },
+              "end": {
+                "$ref": "#/definitions/team-daily-usage/definitions/end_date"
+              }
+            },
+            "required": [
+              "start"
+            ],
+            "type": [
+              "object"
+            ]
+          },
           "rel": "instances",
           "targetSchema": {
             "items": {
@@ -15694,14 +15725,48 @@
           "type": [
             "number"
           ]
+        },
+        "start_date": {
+          "description": "range start date",
+          "example": "2019-01",
+          "pattern": "^[0-9]{4}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "end_date": {
+          "description": "range end date",
+          "example": "2019-02",
+          "pattern": "^[0-9]{4}-[0-9]{2}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
         }
       },
       "links": [
         {
-          "description": "Retrieves usage for an enterprise team for a range of months. Start and end dates can be specified as query parameters using the date format, YYYY-MM format. For example, '/teams/example-team/usage/monthly?start=2019-01&end=2019-02' specifies usage in January and February for 2019. If no end date is specified, one month of usage is returned.",
+          "description": "Retrieves usage for an enterprise team for a range of months. Start and end dates can be specified as query parameters using the date, YYYY-MM. If no end date is specified, one month of usage is returned.\nThe team identifier can be found from the [team list endpoint](https://devcenter.heroku.com/articles/platform-api-reference#team-list).\n",
           "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fid)}/usage/monthly",
           "method": "GET",
           "title": "Info",
+          "schema": {
+            "properties": {
+              "start": {
+                "$ref": "#/definitions/team-monthly-usage/definitions/start_date"
+              },
+              "end": {
+                "$ref": "#/definitions/team-monthly-usage/definitions/end_date"
+              }
+            },
+            "required": [
+              "start"
+            ],
+            "type": [
+              "object"
+            ]
+          },
           "rel": "instances",
           "targetSchema": {
             "items": {
@@ -15937,12 +16002,11 @@
             "id": {
               "$ref": "#/definitions/identity-provider/definitions/id"
             },
-            "slug": {
-              "description": "user-friendly unique identifier for this identity provider",
-              "example": "acme-sso",
-              "type": [
-                "string"
-              ]
+            "name": {
+              "$ref": "#/definitions/identity-provider/definitions/name"
+            },
+            "owner": {
+              "$ref": "#/definitions/identity-provider/definitions/owner"
             }
           }
         },


### PR DESCRIPTION
This commit adds the `log_drain_url` option to `SpaceCreateOpts`, so it
can be passed in on creation. This is for use with
https://devcenter.heroku.com/articles/private-space-logging.

Technically this API is undocumented, but the article and CLI is public.